### PR TITLE
[#5] 공지사항 조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ dependencies {
 
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -43,8 +43,10 @@ dependencies {
 
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // In-memory DB for Test
+    testImplementation 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/src/main/java/hongik/heavyYoung/HeavyYoungApplication.java
+++ b/src/main/java/hongik/heavyYoung/HeavyYoungApplication.java
@@ -5,7 +5,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
-@EnableJpaAuditing
 public class HeavyYoungApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/hongik/heavyYoung/domain/event/controller/EventController.java
+++ b/src/main/java/hongik/heavyYoung/domain/event/controller/EventController.java
@@ -1,0 +1,53 @@
+package hongik.heavyYoung.domain.event.controller;
+
+import hongik.heavyYoung.domain.event.dto.EventResponse;
+import hongik.heavyYoung.domain.event.service.EventQueryService;
+import hongik.heavyYoung.global.apiPayload.ApiResponse;
+import hongik.heavyYoung.global.apiPayload.status.ErrorStatus;
+import hongik.heavyYoung.global.exception.GeneralException;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequestMapping("/events")
+@RequiredArgsConstructor
+public class EventController {
+
+    private final EventQueryService eventService;
+
+    @Operation(summary = "공지사항 조회")
+    @GetMapping("")
+    public ApiResponse<List<EventResponse.EventInfoDTO>> getEvents(
+            @Parameter(description = "시작일 (yyyy-MM-dd)")
+            @RequestParam(value = "from", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            LocalDate from,
+
+            @Parameter(description = "시작일 (yyyy-MM-dd)")
+            @RequestParam(value = "to", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            LocalDate to
+    ) {
+        // 시작일(from), 종료일(to) 둘 중 한 가지 값만 들어온 경우 예외 처리
+        if ((from == null && to != null) || (from != null && to == null)) {
+            throw new GeneralException(ErrorStatus.INVALID_PARAMETER);
+        }
+
+        // 시작일(from)보다 종료일(to)이 앞선 경우 예외 처리
+        if (from != null && to != null && from.isAfter(to)) {
+            throw new GeneralException(ErrorStatus.INVALID_DATE_RANGE);
+        }
+
+        List<EventResponse.EventInfoDTO> allEvents = eventService.getAllEvents(from, to);
+        return ApiResponse.onSuccess(allEvents);
+    };
+}

--- a/src/main/java/hongik/heavyYoung/domain/event/converter/EventResponseConverter.java
+++ b/src/main/java/hongik/heavyYoung/domain/event/converter/EventResponseConverter.java
@@ -1,0 +1,27 @@
+package hongik.heavyYoung.domain.event.converter;
+
+import hongik.heavyYoung.domain.event.dto.EventResponse;
+import hongik.heavyYoung.domain.event.entity.Event;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class EventResponseConverter {
+
+    public static EventResponse.EventInfoDTO toEventInfoDTO(Event event) {
+        return EventResponse.EventInfoDTO.builder()
+                .eventId(event.getId())
+                .title(event.getEventTitle())
+                .eventCreatedAt(event.getCreatedAt())
+                .eventStartAt(event.getEventStartAt())
+                .eventEndAt(event.getEventEndAt())
+                .build();
+    }
+
+    public static List<EventResponse.EventInfoDTO> toEventInfoDTOList(List<Event> events) {
+        return events.stream()
+                .map(EventResponseConverter::toEventInfoDTO)
+                .toList();
+    }
+}

--- a/src/main/java/hongik/heavyYoung/domain/event/dto/EventResponse.java
+++ b/src/main/java/hongik/heavyYoung/domain/event/dto/EventResponse.java
@@ -1,0 +1,24 @@
+package hongik.heavyYoung.domain.event.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public class EventResponse {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class EventInfoDTO{
+        Long eventId;
+        String title;
+        LocalDateTime eventCreatedAt;
+        LocalDate eventStartAt;
+        LocalDate eventEndAt;
+    }
+}

--- a/src/main/java/hongik/heavyYoung/domain/event/repository/EventRepository.java
+++ b/src/main/java/hongik/heavyYoung/domain/event/repository/EventRepository.java
@@ -1,0 +1,11 @@
+package hongik.heavyYoung.domain.event.repository;
+
+import hongik.heavyYoung.domain.event.entity.Event;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface EventRepository extends JpaRepository<Event, Long> {
+    List<Event> findAllByEventStartAtBetween(LocalDate from, LocalDate to);
+}

--- a/src/main/java/hongik/heavyYoung/domain/event/service/EventQueryService.java
+++ b/src/main/java/hongik/heavyYoung/domain/event/service/EventQueryService.java
@@ -1,0 +1,10 @@
+package hongik.heavyYoung.domain.event.service;
+
+import hongik.heavyYoung.domain.event.dto.EventResponse;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface EventQueryService {
+    List<EventResponse.EventInfoDTO> getAllEvents(LocalDate from, LocalDate to);
+}

--- a/src/main/java/hongik/heavyYoung/domain/event/service/impl/EventQueryServiceImpl.java
+++ b/src/main/java/hongik/heavyYoung/domain/event/service/impl/EventQueryServiceImpl.java
@@ -1,0 +1,38 @@
+package hongik.heavyYoung.domain.event.service.impl;
+
+import hongik.heavyYoung.domain.event.converter.EventResponseConverter;
+import hongik.heavyYoung.domain.event.dto.EventResponse;
+import hongik.heavyYoung.domain.event.entity.Event;
+import hongik.heavyYoung.domain.event.repository.EventRepository;
+import hongik.heavyYoung.domain.event.service.EventQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class EventQueryServiceImpl implements EventQueryService {
+
+    private final EventRepository eventRepository;
+
+    @Override
+    public List<EventResponse.EventInfoDTO> getAllEvents(LocalDate from, LocalDate to) {
+        List<Event> allEvents;
+
+        // 시작일, 종료일이 전달된 경우 (기간별 조회)
+        if(from != null &&  to!=null){
+            allEvents = eventRepository.findAllByEventStartAtBetween(from, to);
+        }
+
+        // 시작일, 종료일 둘 다 전달되지 않은 경우 (전체 조회)
+        else{
+            allEvents = eventRepository.findAll();
+        }
+
+        return EventResponseConverter.toEventInfoDTOList(allEvents);
+    }
+}

--- a/src/main/java/hongik/heavyYoung/domain/event/service/impl/EventQueryServiceImpl.java
+++ b/src/main/java/hongik/heavyYoung/domain/event/service/impl/EventQueryServiceImpl.java
@@ -19,6 +19,15 @@ public class EventQueryServiceImpl implements EventQueryService {
 
     private final EventRepository eventRepository;
 
+    /**
+     * 공지사항(Event) 전체 또는 특정 기간의 목록을 조회합니다.
+     * 시작일과 종료일이 모두 전달되면 해당 기간 내의 이벤트만 조회합니다.
+     * 둘 다 전달되지 않으면 전체 이벤트를 조회합니다.
+     *
+     * @param from 조회 시작일 (yyyy-MM-dd), null 허용
+     * @param to   조회 종료일 (yyyy-MM-dd), null 허용
+     * @return 조회된 공지사항(Event) 정보 리스트
+     */
     @Override
     public List<EventResponse.EventInfoDTO> getAllEvents(LocalDate from, LocalDate to) {
         List<Event> allEvents;

--- a/src/main/java/hongik/heavyYoung/global/apiPayload/status/ErrorStatus.java
+++ b/src/main/java/hongik/heavyYoung/global/apiPayload/status/ErrorStatus.java
@@ -11,6 +11,8 @@ import org.springframework.http.HttpStatus;
 public enum ErrorStatus implements BaseErrorCode {
 
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SERVER_001", "서버 에러, 관리자에게 문의 바랍니다."),
+    INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "COMMON_001", "잘못된 요청 파라미터입니다."),
+    INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "COMMON_002", "시작일은 종료일보다 이후일 수 없습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_001", "해당 유저가 존재하지 않습니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/hongik/heavyYoung/global/config/JpaAuditingConfig.java
+++ b/src/main/java/hongik/heavyYoung/global/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package hongik.heavyYoung.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/test/java/hongik/heavyYoung/domain/event/config/EventControllerTestConfig.java
+++ b/src/test/java/hongik/heavyYoung/domain/event/config/EventControllerTestConfig.java
@@ -1,0 +1,15 @@
+package hongik.heavyYoung.domain.event.config;
+
+import hongik.heavyYoung.domain.event.service.EventQueryService;
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class EventControllerTestConfig {
+
+    @Bean
+    public EventQueryService eventQueryService() {
+        return Mockito.mock(EventQueryService.class);
+    }
+}

--- a/src/test/java/hongik/heavyYoung/domain/event/controller/EventControllerTest.java
+++ b/src/test/java/hongik/heavyYoung/domain/event/controller/EventControllerTest.java
@@ -34,7 +34,7 @@ class EventControllerTest {
     @Test
     @DisplayName("공지사항 전체 조회 성공")
     void getEvents_success() throws Exception {
-        //given
+        // given
         EventResponse.EventInfoDTO eventInfoDTO = EventResponse.EventInfoDTO.builder()
                 .eventId(1L)
                 .title("간식행사")
@@ -44,7 +44,7 @@ class EventControllerTest {
                 .build();
         given(eventQueryService.getAllEvents(null, null)).willReturn(List.of(eventInfoDTO));
 
-        //when & then
+        // when & then
         mockMvc.perform(get("/events")
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -59,9 +59,9 @@ class EventControllerTest {
     @Test
     @DisplayName("시작일(from)보다 종료일(to)이 앞선 경우")
     void getEvents_invalidDateRange() throws Exception {
-        //given
+        // given
 
-        //when & then
+        // when & then
         mockMvc.perform(get("/events")
                         .param("from", "2025-09-05")
                         .param("to", "2025-09-01")
@@ -75,9 +75,9 @@ class EventControllerTest {
     @Test
     @DisplayName("파라미터값이 잘못 들어온 경우 - 시작일(from), 종료일(to) 둘 중 한 가지 값만 들어온 경우")
     void getEvents_wrongParameter1() throws Exception {
-        //given
+        // given
 
-        //when & then
+        // when & then
         mockMvc.perform(get("/events")
                         .param("from", "2025-09-01")
                         .accept(MediaType.APPLICATION_JSON))
@@ -90,9 +90,9 @@ class EventControllerTest {
     @Test
     @DisplayName("파라미터값이 잘못 들어온 경우 - 시작일(from), 종료일(to)의 날짜 형식(yyyy-MM-dd)이 맞지 않은 경우")
     void getEvents_wrongParameter2() throws Exception {
-        //given
+        // given
 
-        //when & then
+        // when & then
         mockMvc.perform(get("/events")
                         .param("from", "2025/09/01")
                         .param("to", "2025/09/02")

--- a/src/test/java/hongik/heavyYoung/domain/event/controller/EventControllerTest.java
+++ b/src/test/java/hongik/heavyYoung/domain/event/controller/EventControllerTest.java
@@ -32,7 +32,7 @@ class EventControllerTest {
     private EventQueryService eventQueryService;
 
     @Test
-    @DisplayName("공지사항 전체 조회 성공")
+    @DisplayName("공지사항 조회 성공")
     void getEvents_success() throws Exception {
         // given
         EventResponse.EventInfoDTO eventInfoDTO = EventResponse.EventInfoDTO.builder()
@@ -57,7 +57,7 @@ class EventControllerTest {
     }
 
     @Test
-    @DisplayName("시작일(from)보다 종료일(to)이 앞선 경우")
+    @DisplayName("공지사항 조회시 시작일(from)보다 종료일(to)이 앞선 경우")
     void getEvents_invalidDateRange() throws Exception {
         // given
 
@@ -73,7 +73,7 @@ class EventControllerTest {
     }
 
     @Test
-    @DisplayName("파라미터값이 잘못 들어온 경우 - 시작일(from), 종료일(to) 둘 중 한 가지 값만 들어온 경우")
+    @DisplayName("공지사항 조회시 파라미터값이 잘못 들어온 경우 - 시작일(from), 종료일(to) 둘 중 한 가지 값만 들어온 경우")
     void getEvents_wrongParameter1() throws Exception {
         // given
 
@@ -88,7 +88,7 @@ class EventControllerTest {
     }
 
     @Test
-    @DisplayName("파라미터값이 잘못 들어온 경우 - 시작일(from), 종료일(to)의 날짜 형식(yyyy-MM-dd)이 맞지 않은 경우")
+    @DisplayName("공지사항 조회시 파라미터값이 잘못 들어온 경우 - 시작일(from), 종료일(to)의 날짜 형식(yyyy-MM-dd)이 맞지 않은 경우")
     void getEvents_wrongParameter2() throws Exception {
         // given
 

--- a/src/test/java/hongik/heavyYoung/domain/event/controller/EventControllerTest.java
+++ b/src/test/java/hongik/heavyYoung/domain/event/controller/EventControllerTest.java
@@ -1,0 +1,105 @@
+package hongik.heavyYoung.domain.event.controller;
+
+import hongik.heavyYoung.domain.event.config.EventControllerTestConfig;
+import hongik.heavyYoung.domain.event.dto.EventResponse;
+import hongik.heavyYoung.domain.event.service.EventQueryService;
+import hongik.heavyYoung.global.apiPayload.status.ErrorStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@WebMvcTest(EventController.class)
+@Import(EventControllerTestConfig.class)
+class EventControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private EventQueryService eventQueryService;
+
+    @Test
+    @DisplayName("공지사항 전체 조회 성공")
+    void getEvents_success() throws Exception {
+        //given
+        EventResponse.EventInfoDTO eventInfoDTO = EventResponse.EventInfoDTO.builder()
+                .eventId(1L)
+                .title("간식행사")
+                .eventCreatedAt(LocalDate.of(2025, 8, 31).atStartOfDay())
+                .eventStartAt(LocalDate.of(2025, 9, 1))
+                .eventEndAt(LocalDate.of(2025, 9, 2))
+                .build();
+        given(eventQueryService.getAllEvents(null, null)).willReturn(List.of(eventInfoDTO));
+
+        //when & then
+        mockMvc.perform(get("/events")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.result[0].eventId").value(1L))
+                .andExpect(jsonPath("$.result[0].title").value("간식행사"))
+                .andExpect(jsonPath("$.result[0].eventCreatedAt").value("2025-08-31T00:00:00"))
+                .andExpect(jsonPath("$.result[0].eventStartAt").value("2025-09-01"))
+                .andExpect(jsonPath("$.result[0].eventEndAt").value("2025-09-02"));
+    }
+
+    @Test
+    @DisplayName("시작일(from)보다 종료일(to)이 앞선 경우")
+    void getEvents_invalidDateRange() throws Exception {
+        //given
+
+        //when & then
+        mockMvc.perform(get("/events")
+                        .param("from", "2025-09-05")
+                        .param("to", "2025-09-01")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.code").value(ErrorStatus.INVALID_DATE_RANGE.getCode()))
+                .andExpect(jsonPath("$.message").value("시작일은 종료일보다 이후일 수 없습니다."));
+    }
+
+    @Test
+    @DisplayName("파라미터값이 잘못 들어온 경우 - 시작일(from), 종료일(to) 둘 중 한 가지 값만 들어온 경우")
+    void getEvents_wrongParameter1() throws Exception {
+        //given
+
+        //when & then
+        mockMvc.perform(get("/events")
+                        .param("from", "2025-09-01")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.code").value(ErrorStatus.INVALID_PARAMETER.getCode()))
+                .andExpect(jsonPath("$.message").value("잘못된 요청 파라미터입니다."));
+    }
+
+    @Test
+    @DisplayName("파라미터값이 잘못 들어온 경우 - 시작일(from), 종료일(to)의 날짜 형식(yyyy-MM-dd)이 맞지 않은 경우")
+    void getEvents_wrongParameter2() throws Exception {
+        //given
+
+        //when & then
+        mockMvc.perform(get("/events")
+                        .param("from", "2025/09/01")
+                        .param("to", "2025/09/02")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.code").value(ErrorStatus.INVALID_PARAMETER.getCode()))
+                .andExpect(jsonPath("$.message").value("잘못된 요청 파라미터입니다."));
+    }
+}

--- a/src/test/java/hongik/heavyYoung/domain/event/integration/EventIntegrationTest.java
+++ b/src/test/java/hongik/heavyYoung/domain/event/integration/EventIntegrationTest.java
@@ -1,0 +1,84 @@
+package hongik.heavyYoung.domain.event.integration;
+
+import hongik.heavyYoung.domain.event.entity.Event;
+import hongik.heavyYoung.domain.event.repository.EventRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDate;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class EventIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @BeforeEach
+    void setUp(){
+        Event event1 = Event.builder()
+                .eventTitle("간식행사")
+                .eventContent("간식행사 상세 일정")
+                .eventStartAt(LocalDate.of(2025, 9, 1))
+                .eventEndAt(LocalDate.of(2025, 9, 2))
+                .build();
+
+        Event event2 = Event.builder()
+                .eventTitle("나눔행사")
+                .eventContent("나눔행사 상세 일정")
+                .eventStartAt(LocalDate.of(2025, 10, 1))
+                .eventEndAt(LocalDate.of(2025, 10, 2))
+                .build();
+
+        eventRepository.save(event1);
+        eventRepository.save(event2);
+    }
+
+    @Test
+    @DisplayName("공지사항 조회(전체) 통합테스트")
+    void getEvents_All_API() throws Exception{
+        mockMvc.perform(get("/events")
+                    .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.result.length()").value(2))
+                .andExpect(jsonPath("$.result[0].title").value("간식행사"))
+                .andExpect(jsonPath("$.result[0].eventStartAt").value("2025-09-01"))
+                .andExpect(jsonPath("$.result[0].eventEndAt").value("2025-09-02"))
+                .andExpect(jsonPath("$.result[1].title").value("나눔행사"))
+                .andExpect(jsonPath("$.result[1].eventStartAt").value("2025-10-01"))
+                .andExpect(jsonPath("$.result[1].eventEndAt").value("2025-10-02"));
+
+    }
+
+    @Test
+    @DisplayName("공지사항 조회(기간별) 통합테스트")
+    void getEvents_Period_API() throws Exception{
+        mockMvc.perform(get("/events")
+                        .param("from", "2025-09-01")
+                        .param("to", "2025-09-30")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.result.length()").value(1))
+                .andExpect(jsonPath("$.result[0].title").value("간식행사"))
+                .andExpect(jsonPath("$.result[0].eventStartAt").value("2025-09-01"))
+                .andExpect(jsonPath("$.result[0].eventEndAt").value("2025-09-02"));
+    }
+
+}

--- a/src/test/java/hongik/heavyYoung/domain/event/repository/EventRepositoryTest.java
+++ b/src/test/java/hongik/heavyYoung/domain/event/repository/EventRepositoryTest.java
@@ -22,7 +22,7 @@ class EventRepositoryTest {
     private EventRepository eventRepository;
 
     @Test
-    @DisplayName("공지사항 조회(기간별) 성공")
+    @DisplayName("공지사항 조회(전체) 성공")
     void findAll(){
         // given
         Event event1 = Event.builder()
@@ -47,8 +47,8 @@ class EventRepositoryTest {
 
         // then
         assertThat(result).hasSize(2);
-        assertEquals(result.getFirst().getId(), 1L);
-        assertEquals(result.get(1).getId(),2L);
+        assertEquals(result.getFirst().getEventTitle(), "간식행사");
+        assertEquals(result.get(1).getEventTitle(),"나눔행사");
     }
 
     @Test
@@ -80,6 +80,6 @@ class EventRepositoryTest {
 
         // then
         assertThat(result).hasSize(1);
-        assertThat(result.getFirst().getEventTitle()).isEqualTo("간식행사");
+        assertEquals(result.getFirst().getEventTitle(), "간식행사");
     }
 }

--- a/src/test/java/hongik/heavyYoung/domain/event/repository/EventRepositoryTest.java
+++ b/src/test/java/hongik/heavyYoung/domain/event/repository/EventRepositoryTest.java
@@ -1,0 +1,85 @@
+package hongik.heavyYoung.domain.event.repository;
+
+import hongik.heavyYoung.domain.event.entity.Event;
+import hongik.heavyYoung.global.config.JpaAuditingConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DataJpaTest
+@Import(JpaAuditingConfig.class)
+class EventRepositoryTest {
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @Test
+    @DisplayName("공지사항 조회(기간별) 성공")
+    void findAll(){
+        // given
+        Event event1 = Event.builder()
+                .eventTitle("간식행사")
+                .eventContent("간식행사 상세 일정")
+                .eventStartAt(LocalDate.of(2025, 9, 1))
+                .eventEndAt(LocalDate.of(2025, 9, 2))
+                .build();
+
+        Event event2 = Event.builder()
+                .eventTitle("나눔행사")
+                .eventContent("나눔행사 상세 일정")
+                .eventStartAt(LocalDate.of(2025, 10, 1))
+                .eventEndAt(LocalDate.of(2025, 10, 2))
+                .build();
+
+        eventRepository.save(event1);
+        eventRepository.save(event2);
+
+        // when
+        List<Event> result = eventRepository.findAll();
+
+        // then
+        assertThat(result).hasSize(2);
+        assertEquals(result.getFirst().getId(), 1L);
+        assertEquals(result.get(1).getId(),2L);
+    }
+
+    @Test
+    @DisplayName("공지사항 조회(기간별) 성공")
+    void findAllByEventStartAtBetween() {
+        // given
+        Event event1 = Event.builder()
+                .eventTitle("간식행사")
+                .eventContent("간식행사 상세 일정")
+                .eventStartAt(LocalDate.of(2025, 9, 1))
+                .eventEndAt(LocalDate.of(2025, 9, 2))
+                .build();
+
+        Event event2 = Event.builder()
+                .eventTitle("나눔행사")
+                .eventContent("나눔행사 상세 일정")
+                .eventStartAt(LocalDate.of(2025, 10, 1))
+                .eventEndAt(LocalDate.of(2025, 10, 2))
+                .build();
+
+        eventRepository.save(event1);
+        eventRepository.save(event2);
+
+        // when
+        List<Event> result = eventRepository.findAllByEventStartAtBetween(
+                LocalDate.of(2025, 9, 1),
+                LocalDate.of(2025, 9, 30)
+        );
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().getEventTitle()).isEqualTo("간식행사");
+    }
+}

--- a/src/test/java/hongik/heavyYoung/domain/event/service/impl/EventQueryServiceImplTest.java
+++ b/src/test/java/hongik/heavyYoung/domain/event/service/impl/EventQueryServiceImplTest.java
@@ -28,7 +28,7 @@ class EventQueryServiceImplTest {
     private EventQueryServiceImpl eventQueryService;
 
     @Test
-    @DisplayName("공지사항 전체 조회 성공")
+    @DisplayName("공지사항 조회(전체) 성공")
     void getAllEvents_success() {
         // given
         List<Event> events = new ArrayList<>();
@@ -64,7 +64,7 @@ class EventQueryServiceImplTest {
     }
 
     @Test
-    @DisplayName("공지사항 날짜별 조회 성공")
+    @DisplayName("공지사항 조회(기간별) 성공")
     void getAllEventsWithPeriod_success() {
         // given
         LocalDate from = LocalDate.of(2025, 9, 1);

--- a/src/test/java/hongik/heavyYoung/domain/event/service/impl/EventQueryServiceImplTest.java
+++ b/src/test/java/hongik/heavyYoung/domain/event/service/impl/EventQueryServiceImplTest.java
@@ -1,0 +1,90 @@
+package hongik.heavyYoung.domain.event.service.impl;
+
+import hongik.heavyYoung.domain.event.dto.EventResponse;
+import hongik.heavyYoung.domain.event.entity.Event;
+import hongik.heavyYoung.domain.event.repository.EventRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class EventQueryServiceImplTest {
+
+    @Mock
+    private EventRepository eventRepository;
+
+    @InjectMocks
+    private EventQueryServiceImpl eventQueryService;
+
+    @Test
+    @DisplayName("공지사항 전체 조회 성공")
+    void getAllEvents_success() {
+        // given
+        List<Event> events = new ArrayList<>();
+
+        Event event1 = Event.builder()
+                .id(1L)
+                .eventTitle("간식행사")
+                .eventContent("간식행사 상세 일정")
+                .eventStartAt(LocalDate.of(2025, 9, 1))
+                .eventEndAt(LocalDate.of(2025, 9, 2))
+                .build();
+
+        Event event2 = Event.builder()
+                .id(2L)
+                .eventTitle("나눔행사")
+                .eventContent("나눔행사 상세 일정")
+                .eventStartAt(LocalDate.of(2025, 9, 1))
+                .eventEndAt(LocalDate.of(2025, 9, 2))
+                .build();
+
+        events.add(event1);
+        events.add(event2);
+
+        given(eventRepository.findAll()).willReturn(events);
+
+        // when
+        List<EventResponse.EventInfoDTO> result = eventQueryService.getAllEvents(null, null);
+
+        // then
+        assertThat(result).hasSize(2);
+        assertEquals(result.getFirst().getEventId(), 1L);
+        assertEquals(result.get(1).getEventId(),2L);
+    }
+
+    @Test
+    @DisplayName("공지사항 날짜별 조회 성공")
+    void getAllEventsWithPeriod_success() {
+        // given
+        LocalDate from = LocalDate.of(2025, 9, 1);
+        LocalDate to = LocalDate.of(2025, 9, 2);
+
+        Event event1 = Event.builder()
+                .id(1L)
+                .eventTitle("간식행사")
+                .eventContent("간식행사 상세 일정")
+                .eventStartAt(LocalDate.of(2025, 9, 1))
+                .eventEndAt(LocalDate.of(2025, 9, 2))
+                .build();
+
+        given(eventRepository.findAllByEventStartAtBetween(from,to)).willReturn(List.of(event1));
+
+        // when
+        List<EventResponse.EventInfoDTO> result = eventQueryService.getAllEvents(from, to);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertEquals(result.getFirst().getEventId(), 1L);
+    }
+}

--- a/src/test/java/hongik/heavyYoung/global/config/JpaAuditingConfig.java
+++ b/src/test/java/hongik/heavyYoung/global/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package hongik.heavyYoung.global.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@TestConfiguration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,19 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:heavyYoung;DB_CLOSE_DELAY=-1;MODE=MySQL
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.H2Dialect
+
+  h2:
+    console:
+      enabled: true


### PR DESCRIPTION
## 🔗 관련 이슈
closes #5 

## 📖 변경 사항 요약
- 공지사항 조회 기능 구현
- ExceptionAdvice에 잘못된 RequestParam에 대한 공통 예외처리 추가
- @EnableJpaAuditing -> JpaAuditingConfig 파일로 이동
- 공지사항 조회 테스트 코드 구현
- 테스트 코드용 인메모리 DB 의존성 추가
- 테스트 코드용 공통 application-test.yml파일 작성

## 🛠 구현 내용 및 상세
**1. 공지사항 조회 기능 구현**
- 공지사항 조회 기능을 구현했습니다.
- 시작일(from), 종료일(to)을 RequestParam으로 받아 기간별 조회 방식과 전체 조회 방식을 구현했습니다.
- 시작일과 종료일 중 하나의 값만 입력한 경우, 시작일보다 종료일이 앞선 경우 예외 처리를 했습니다.

**2. ExceptionAdvice에 잘못된 RequestParam에 대한 공통 예외처리 추가**
- ExceptionAdvice에서 잘못된 RequestParam으로 요청이 온 경우, INVALID_PARAMETER로 공통 응답으로 예외가 처리되게 했습니다.

**3. 공지사항 조회 테스트 코드 구현**
- EventController, EventService, EventRepository 각각의 단위 테스트 코드를 작성했습니다.
- 이후 공지사항 조회 API 통합 테스트 코드를 작성했습니다.
- 테스트 환경에 필요해 인메모리 H2 DB 의존성을 추가했습니다.
- 테스트 환경에 필요한 application-test.yml파일을 작성했습니다.


## 📋 리뷰 요구사항
- 테스트 코드 작성한 부분 봐주시면 좋겠습니다.
- DTO, Converter 구성한 방식이 올바른지 모르겠습니다.
- 주석,변수명, 테스트 코드 함수명 등이 헷갈려 그 부분 봐주시면 좋겠습니다.

## 💬 참고 사항
- JpaAuditingConfig로 분리한 이유, 테스트 코드 작성 과정은 노션에 더 자세히 정리해 두었습니다.