### PR TITLE
[#7] 공지사항 상세보기, 생성

### DIFF
--- a/src/main/java/hongik/heavyYoung/domain/event/controller/EventRestController.java
+++ b/src/main/java/hongik/heavyYoung/domain/event/controller/EventRestController.java
@@ -17,7 +17,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/events")
-@Tag(name = "Event API", description = "공지사항 관련 API")
+@Tag(name = "Event API - 학생", description = "학생 - 공지사항 관련 API")
 @RequiredArgsConstructor
 public class EventRestController {
 

--- a/src/main/java/hongik/heavyYoung/domain/event/controller/EventRestController.java
+++ b/src/main/java/hongik/heavyYoung/domain/event/controller/EventRestController.java
@@ -10,10 +10,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -49,7 +46,17 @@ public class EventRestController {
             throw new GeneralException(ErrorStatus.INVALID_DATE_RANGE);
         }
 
-        List<EventResponse.EventInfoDTO> allEvents = eventService.getAllEvents(from, to);
+        List<EventResponse.EventInfoDTO> allEvents = eventService.findEvents(from, to);
         return ApiResponse.onSuccess(allEvents);
     }
+
+    @Operation(summary = "공지사항 상세 조회")
+    @GetMapping("/{eventId}")
+    public ApiResponse<EventResponse.EventInfoDetailDTO> getEventDetails(
+            @PathVariable("eventId") Long eventId
+    ) {
+        EventResponse.EventInfoDetailDTO eventDetails = eventService.findEventDetails(eventId);
+        return ApiResponse.onSuccess(eventDetails);
+    }
+
 }

--- a/src/main/java/hongik/heavyYoung/domain/event/controller/EventRestController.java
+++ b/src/main/java/hongik/heavyYoung/domain/event/controller/EventRestController.java
@@ -25,7 +25,7 @@ public class EventRestController {
 
     @Operation(summary = "공지사항 조회")
     @GetMapping
-    public ApiResponse<List<EventResponse.EventInfoDTO>> getEvents(
+    public ApiResponse<List<EventResponse.EventInfoDTO>> getEvents (
             @Parameter(description = "시작일 (yyyy-MM-dd)", example = "2025-09-01")
             @RequestParam(value = "from", required = false)
             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)

--- a/src/main/java/hongik/heavyYoung/domain/event/controller/EventRestController.java
+++ b/src/main/java/hongik/heavyYoung/domain/event/controller/EventRestController.java
@@ -52,7 +52,7 @@ public class EventRestController {
 
     @Operation(summary = "공지사항 상세 조회")
     @GetMapping("/{eventId}")
-    public ApiResponse<EventResponse.EventInfoDetailDTO> getEventDetails(
+    public ApiResponse<EventResponse.EventInfoDetailDTO> getEventDetails (
             @PathVariable("eventId") Long eventId
     ) {
         EventResponse.EventInfoDetailDTO eventDetails = eventService.findEventDetails(eventId);

--- a/src/main/java/hongik/heavyYoung/domain/event/controller/admin/AdminEventRestController.java
+++ b/src/main/java/hongik/heavyYoung/domain/event/controller/admin/AdminEventRestController.java
@@ -1,0 +1,32 @@
+package hongik.heavyYoung.domain.event.controller.admin;
+
+import hongik.heavyYoung.domain.event.dto.EventRequest;
+import hongik.heavyYoung.domain.event.dto.EventResponse;
+import hongik.heavyYoung.domain.event.service.admin.AdminEventCommandService;
+import hongik.heavyYoung.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/admin/events")
+@Tag(name = "Event API - 학생회", description = "학생회 - 공지사항 관련 API")
+@RequiredArgsConstructor
+public class AdminEventRestController {
+
+    private final AdminEventCommandService adminEventCommandService;
+
+    @PostMapping
+    public ApiResponse<EventResponse.EventAddResponseDTO> addEvent(
+            @RequestBody @Valid EventRequest.EventAddRequestDTO eventAddRequestDTO
+    ) {
+        EventResponse.EventAddResponseDTO eventAddResponseDTO = adminEventCommandService.createEvent(eventAddRequestDTO);
+        return ApiResponse.onSuccess(eventAddResponseDTO);
+    }
+
+
+}

--- a/src/main/java/hongik/heavyYoung/domain/event/controller/admin/AdminEventRestController.java
+++ b/src/main/java/hongik/heavyYoung/domain/event/controller/admin/AdminEventRestController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/admin/events")
+@RequestMapping("/admin/event")
 @Tag(name = "Event API - 학생회", description = "학생회 - 공지사항 관련 API")
 @RequiredArgsConstructor
 public class AdminEventRestController {
@@ -21,7 +21,7 @@ public class AdminEventRestController {
     private final AdminEventCommandService adminEventCommandService;
 
     @PostMapping
-    public ApiResponse<EventResponse.EventAddResponseDTO> addEvent(
+    public ApiResponse<EventResponse.EventAddResponseDTO> addEvent (
             @RequestBody @Valid EventRequest.EventAddRequestDTO eventAddRequestDTO
     ) {
         EventResponse.EventAddResponseDTO eventAddResponseDTO = adminEventCommandService.createEvent(eventAddRequestDTO);

--- a/src/main/java/hongik/heavyYoung/domain/event/converter/EventRequestConverter.java
+++ b/src/main/java/hongik/heavyYoung/domain/event/converter/EventRequestConverter.java
@@ -1,0 +1,19 @@
+package hongik.heavyYoung.domain.event.converter;
+
+import hongik.heavyYoung.domain.event.dto.EventRequest;
+import hongik.heavyYoung.domain.event.entity.Event;
+import org.springframework.stereotype.Component;
+
+@Component
+public class EventRequestConverter {
+
+    public static Event toNewEntity(EventRequest.EventAddRequestDTO eventAddRequestDTO) {
+        return Event.builder()
+                .eventTitle(eventAddRequestDTO.getTitle())
+                .eventContent(eventAddRequestDTO.getContent())
+                .eventStartDate(eventAddRequestDTO.getEventStartDate())
+                .eventEndDate(eventAddRequestDTO.getEventEndDate())
+                // TODO 사진 업로드 방식 결정 후, imageUrl 혹은 Multipart 추가
+                .build();
+    }
+}

--- a/src/main/java/hongik/heavyYoung/domain/event/converter/EventRequestConverter.java
+++ b/src/main/java/hongik/heavyYoung/domain/event/converter/EventRequestConverter.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class EventRequestConverter {
 
-    public static Event toNewEntity(EventRequest.EventAddRequestDTO eventAddRequestDTO) {
+    public static Event toNewEvent(EventRequest.EventAddRequestDTO eventAddRequestDTO) {
         return Event.builder()
                 .eventTitle(eventAddRequestDTO.getTitle())
                 .eventContent(eventAddRequestDTO.getContent())

--- a/src/main/java/hongik/heavyYoung/domain/event/converter/EventResponseConverter.java
+++ b/src/main/java/hongik/heavyYoung/domain/event/converter/EventResponseConverter.java
@@ -41,4 +41,10 @@ public class EventResponseConverter {
                         .toList())
                 .build();
     }
+
+    public static EventResponse.EventAddResponseDTO toEventAddResponseDTO(Event event) {
+        return EventResponse.EventAddResponseDTO.builder()
+                .eventId(event.getId())
+                .build();
+    }
 }

--- a/src/main/java/hongik/heavyYoung/domain/event/converter/EventResponseConverter.java
+++ b/src/main/java/hongik/heavyYoung/domain/event/converter/EventResponseConverter.java
@@ -2,6 +2,7 @@ package hongik.heavyYoung.domain.event.converter;
 
 import hongik.heavyYoung.domain.event.dto.EventResponse;
 import hongik.heavyYoung.domain.event.entity.Event;
+import hongik.heavyYoung.domain.event.entity.EventImage;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -24,5 +25,20 @@ public class EventResponseConverter {
         return events.stream()
                 .map(EventResponseConverter::toEventInfoDTO)
                 .toList();
+    }
+
+    public static EventResponse.EventInfoDetailDTO toEventInfoDetailDTO(Event event) {
+        return EventResponse.EventInfoDetailDTO.builder()
+                .eventId(event.getId())
+                .title(event.getEventTitle())
+                .content(event.getEventContent())
+                .eventStartDate(event.getEventStartDate())
+                .eventEndDate(event.getEventEndDate())
+                .eventCreatedAt(event.getCreatedAt())
+                .eventUpdatedAt(event.getUpdatedAt())
+                .imageUrls(event.getEventImages().stream()
+                        .map(EventImage::getEventImageUrl)
+                        .toList())
+                .build();
     }
 }

--- a/src/main/java/hongik/heavyYoung/domain/event/converter/EventResponseConverter.java
+++ b/src/main/java/hongik/heavyYoung/domain/event/converter/EventResponseConverter.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 @Component
 public class EventResponseConverter {
-
+    // 공지사항 기본 정보
     public static EventResponse.EventInfoDTO toEventInfoDTO(Event event) {
         return EventResponse.EventInfoDTO.builder()
                 .eventId(event.getId())
@@ -20,12 +20,14 @@ public class EventResponseConverter {
                 .build();
     }
 
+    // 공지사항 기본 정보를 리스트로 변환
     public static List<EventResponse.EventInfoDTO> toEventInfoDTOList(List<Event> events) {
         return events.stream()
                 .map(EventResponseConverter::toEventInfoDTO)
                 .toList();
     }
 
+    // 공지사항 상세 정보
     public static EventResponse.EventInfoDetailDTO toEventInfoDetailDTO(Event event) {
         return EventResponse.EventInfoDetailDTO.builder()
                 .eventId(event.getId())

--- a/src/main/java/hongik/heavyYoung/domain/event/converter/EventResponseConverter.java
+++ b/src/main/java/hongik/heavyYoung/domain/event/converter/EventResponseConverter.java
@@ -15,7 +15,6 @@ public class EventResponseConverter {
                 .eventId(event.getId())
                 .title(event.getEventTitle())
                 .eventCreatedAt(event.getCreatedAt())
-                .eventUpdatedAt(event.getUpdatedAt())
                 .eventStartDate(event.getEventStartDate())
                 .eventEndDate(event.getEventEndDate())
                 .build();
@@ -35,7 +34,6 @@ public class EventResponseConverter {
                 .eventStartDate(event.getEventStartDate())
                 .eventEndDate(event.getEventEndDate())
                 .eventCreatedAt(event.getCreatedAt())
-                .eventUpdatedAt(event.getUpdatedAt())
                 .imageUrls(event.getEventImages().stream()
                         .map(EventImage::getEventImageUrl)
                         .toList())

--- a/src/main/java/hongik/heavyYoung/domain/event/dto/EventRequest.java
+++ b/src/main/java/hongik/heavyYoung/domain/event/dto/EventRequest.java
@@ -1,0 +1,28 @@
+package hongik.heavyYoung.domain.event.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+public class EventRequest {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class EventAddRequestDTO {
+        @Schema(description = "공지사항 제목")
+        private String title;
+        @Schema(description = "공지사항 내용")
+        private String content;
+        @Schema(description = "행사 시작일")
+        private LocalDate eventStartDate;
+        @Schema(description = "행사 종료일")
+        private LocalDate eventEndDate;
+        // TODO 사진 업로드 방식 결정 후, imageUrl 혹은 Multipart 추가
+    }
+}

--- a/src/main/java/hongik/heavyYoung/domain/event/dto/EventRequest.java
+++ b/src/main/java/hongik/heavyYoung/domain/event/dto/EventRequest.java
@@ -1,6 +1,7 @@
 package hongik.heavyYoung.domain.event.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,8 +17,10 @@ public class EventRequest {
     @AllArgsConstructor
     public static class EventAddRequestDTO {
         @Schema(description = "공지사항 제목")
+        @NotBlank(message = "제목은 필수 입력 값입니다.")
         private String title;
         @Schema(description = "공지사항 내용")
+        @NotBlank(message = "내용은 필수 입력 값입니다.")
         private String content;
         @Schema(description = "행사 시작일")
         private LocalDate eventStartDate;

--- a/src/main/java/hongik/heavyYoung/domain/event/dto/EventRequest.java
+++ b/src/main/java/hongik/heavyYoung/domain/event/dto/EventRequest.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDate;
 
 public class EventRequest {
-
+    // 공지사항 생성 요청 DTO
     @Getter
     @Builder
     @NoArgsConstructor

--- a/src/main/java/hongik/heavyYoung/domain/event/dto/EventResponse.java
+++ b/src/main/java/hongik/heavyYoung/domain/event/dto/EventResponse.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class EventResponse {
 
@@ -31,5 +32,30 @@ public class EventResponse {
         private LocalDate eventStartDate;
         @Schema(description = "행사 종료일")
         private LocalDate eventEndDate;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class EventInfoDetailDTO{
+        @Schema(description = "공지사항 PK")
+        private Long eventId;
+        @Schema(description = "공지사항 제목")
+        private String title;
+        @Schema(description = "공지사항 내용")
+        private String content;
+        @Schema(description = "행사 시작일")
+        private LocalDate eventStartDate;
+        @Schema(description = "행사 종료일")
+        private LocalDate eventEndDate;
+        @Schema(description = "공지사항 생성 시간", example = "2025-08-31 00:00:00")
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+        private LocalDateTime eventCreatedAt;
+        @Schema(description = "공지사항 수정 시간", example = "2025-08-31 12:30:45")
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+        private LocalDateTime eventUpdatedAt;
+        @Schema(description = "공지사항 사진")
+        private List<String> imageUrls;
     }
 }

--- a/src/main/java/hongik/heavyYoung/domain/event/dto/EventResponse.java
+++ b/src/main/java/hongik/heavyYoung/domain/event/dto/EventResponse.java
@@ -17,7 +17,7 @@ public class EventResponse {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class EventInfoDTO{
+    public static class EventInfoDTO {
         @Schema(description = "공지사항 PK")
         private Long eventId;
         @Schema(description = "공지사항 제목")
@@ -38,7 +38,7 @@ public class EventResponse {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class EventInfoDetailDTO{
+    public static class EventInfoDetailDTO {
         @Schema(description = "공지사항 PK")
         private Long eventId;
         @Schema(description = "공지사항 제목")
@@ -57,5 +57,14 @@ public class EventResponse {
         private LocalDateTime eventUpdatedAt;
         @Schema(description = "공지사항 사진")
         private List<String> imageUrls;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class EventAddResponseDTO{
+        @Schema(description = "공지사항 PK")
+        private Long eventId;
     }
 }

--- a/src/main/java/hongik/heavyYoung/domain/event/dto/EventResponse.java
+++ b/src/main/java/hongik/heavyYoung/domain/event/dto/EventResponse.java
@@ -25,9 +25,6 @@ public class EventResponse {
         @Schema(description = "공지사항 생성 시간", example = "2025-08-31 00:00:00")
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         private LocalDateTime eventCreatedAt;
-        @Schema(description = "공지사항 수정 시간", example = "2025-08-31 12:30:45")
-        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
-        private LocalDateTime eventUpdatedAt;
         @Schema(description = "행사 시작일")
         private LocalDate eventStartDate;
         @Schema(description = "행사 종료일")
@@ -52,9 +49,6 @@ public class EventResponse {
         @Schema(description = "공지사항 생성 시간", example = "2025-08-31 00:00:00")
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         private LocalDateTime eventCreatedAt;
-        @Schema(description = "공지사항 수정 시간", example = "2025-08-31 12:30:45")
-        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
-        private LocalDateTime eventUpdatedAt;
         @Schema(description = "공지사항 사진")
         private List<String> imageUrls;
     }
@@ -63,7 +57,7 @@ public class EventResponse {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class EventAddResponseDTO{
+    public static class EventAddResponseDTO {
         @Schema(description = "공지사항 PK")
         private Long eventId;
     }

--- a/src/main/java/hongik/heavyYoung/domain/event/dto/EventResponse.java
+++ b/src/main/java/hongik/heavyYoung/domain/event/dto/EventResponse.java
@@ -12,7 +12,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public class EventResponse {
-
+    // 공지사항 기본 정보 DTO
     @Getter
     @Builder
     @NoArgsConstructor
@@ -31,6 +31,7 @@ public class EventResponse {
         private LocalDate eventEndDate;
     }
 
+    // 공지사항 상세 정보 DTO
     @Getter
     @Builder
     @NoArgsConstructor
@@ -53,6 +54,8 @@ public class EventResponse {
         private List<String> imageUrls;
     }
 
+
+    // 공지사항 생성시 응답 DTO
     @Getter
     @Builder
     @NoArgsConstructor

--- a/src/main/java/hongik/heavyYoung/domain/event/entity/Event.java
+++ b/src/main/java/hongik/heavyYoung/domain/event/entity/Event.java
@@ -34,7 +34,7 @@ public class Event extends BaseEntity {
     private LocalDate eventEndDate;
 
     @Builder.Default
-    @OneToMany(mappedBy = "event", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "event", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     @OrderBy("sortOrder ASC")
     private List<EventImage> eventImages = new ArrayList<>();
 }

--- a/src/main/java/hongik/heavyYoung/domain/event/entity/Event.java
+++ b/src/main/java/hongik/heavyYoung/domain/event/entity/Event.java
@@ -5,6 +5,8 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Builder
@@ -30,4 +32,9 @@ public class Event extends BaseEntity {
 
     @Column(name = "event_end_date")
     private LocalDate eventEndDate;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "event", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("sortOrder ASC")
+    private List<EventImage> eventImages = new ArrayList<>();
 }

--- a/src/main/java/hongik/heavyYoung/domain/event/entity/EventImage.java
+++ b/src/main/java/hongik/heavyYoung/domain/event/entity/EventImage.java
@@ -23,4 +23,7 @@ public class EventImage extends BaseEntity {
     @Lob
     @Column(name = "event_image_url", nullable = false)
     private String eventImageUrl;
+
+    @Column(name = "sort_order")
+    private int sortOrder;
 }

--- a/src/main/java/hongik/heavyYoung/domain/event/repository/EventRepository.java
+++ b/src/main/java/hongik/heavyYoung/domain/event/repository/EventRepository.java
@@ -10,8 +10,8 @@ import java.util.List;
 import java.util.Optional;
 
 public interface EventRepository extends JpaRepository<Event, Long> {
-    List<Event> findAllByOrderByUpdatedAtDesc();
-    List<Event> findAllByEventStartDateBetweenOrderByUpdatedAtDesc(LocalDate from, LocalDate to);
+    List<Event> findAllByOrderByCreatedAtDesc();
+    List<Event> findAllByEventStartDateBetweenOrderByCreatedAtDesc(LocalDate from, LocalDate to);
     @Query("SELECT DISTINCT e FROM Event e LEFT JOIN FETCH e.eventImages WHERE e.id = :id")
     Optional<Event> findByIdWithImages(@Param("id") Long id);
 }

--- a/src/main/java/hongik/heavyYoung/domain/event/repository/EventRepository.java
+++ b/src/main/java/hongik/heavyYoung/domain/event/repository/EventRepository.java
@@ -2,11 +2,16 @@ package hongik.heavyYoung.domain.event.repository;
 
 import hongik.heavyYoung.domain.event.entity.Event;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 public interface EventRepository extends JpaRepository<Event, Long> {
     List<Event> findAllByOrderByUpdatedAtDesc();
     List<Event> findAllByEventStartDateBetweenOrderByUpdatedAtDesc(LocalDate from, LocalDate to);
+    @Query("SELECT DISTINCT e FROM Event e LEFT JOIN FETCH e.eventImages WHERE e.id = :id")
+    Optional<Event> findByIdWithImages(@Param("id") Long id);
 }

--- a/src/main/java/hongik/heavyYoung/domain/event/service/EventQueryService.java
+++ b/src/main/java/hongik/heavyYoung/domain/event/service/EventQueryService.java
@@ -6,5 +6,6 @@ import java.time.LocalDate;
 import java.util.List;
 
 public interface EventQueryService {
-    List<EventResponse.EventInfoDTO> getAllEvents(LocalDate from, LocalDate to);
+    List<EventResponse.EventInfoDTO> findEvents(LocalDate from, LocalDate to);
+    EventResponse.EventInfoDetailDTO findEventDetails(Long id);
 }

--- a/src/main/java/hongik/heavyYoung/domain/event/service/admin/AdminEventCommandService.java
+++ b/src/main/java/hongik/heavyYoung/domain/event/service/admin/AdminEventCommandService.java
@@ -1,0 +1,8 @@
+package hongik.heavyYoung.domain.event.service.admin;
+
+import hongik.heavyYoung.domain.event.dto.EventRequest;
+import hongik.heavyYoung.domain.event.dto.EventResponse;
+
+public interface AdminEventCommandService {
+    EventResponse.EventAddResponseDTO createEvent(EventRequest.EventAddRequestDTO eventAddRequestDTO);
+}

--- a/src/main/java/hongik/heavyYoung/domain/event/service/admin/impl/AdminEventCommandServiceImpl.java
+++ b/src/main/java/hongik/heavyYoung/domain/event/service/admin/impl/AdminEventCommandServiceImpl.java
@@ -21,8 +21,8 @@ public class AdminEventCommandServiceImpl implements AdminEventCommandService {
     @Override
     @Transactional
     public EventResponse.EventAddResponseDTO createEvent(EventRequest.EventAddRequestDTO eventAddRequestDTO) {
-        Event event = EventRequestConverter.toNewEntity(eventAddRequestDTO);
-        eventRepository.save(event);
-        return EventResponseConverter.toEventAddResponseDTO(event);
+        Event event = EventRequestConverter.toNewEvent(eventAddRequestDTO);
+        Event savedEvent = eventRepository.save(event);
+        return EventResponseConverter.toEventAddResponseDTO(savedEvent);
     }
 }

--- a/src/main/java/hongik/heavyYoung/domain/event/service/admin/impl/AdminEventCommandServiceImpl.java
+++ b/src/main/java/hongik/heavyYoung/domain/event/service/admin/impl/AdminEventCommandServiceImpl.java
@@ -1,0 +1,28 @@
+package hongik.heavyYoung.domain.event.service.admin.impl;
+
+import hongik.heavyYoung.domain.event.converter.EventRequestConverter;
+import hongik.heavyYoung.domain.event.converter.EventResponseConverter;
+import hongik.heavyYoung.domain.event.dto.EventRequest;
+import hongik.heavyYoung.domain.event.dto.EventResponse;
+import hongik.heavyYoung.domain.event.entity.Event;
+import hongik.heavyYoung.domain.event.repository.EventRepository;
+import hongik.heavyYoung.domain.event.service.admin.AdminEventCommandService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AdminEventCommandServiceImpl implements AdminEventCommandService {
+
+    private final EventRepository eventRepository;
+
+    @Override
+    @Transactional
+    public EventResponse.EventAddResponseDTO createEvent(EventRequest.EventAddRequestDTO eventAddRequestDTO) {
+        Event event = EventRequestConverter.toNewEntity(eventAddRequestDTO);
+        eventRepository.save(event);
+        return EventResponseConverter.toEventAddResponseDTO(event);
+    }
+}

--- a/src/main/java/hongik/heavyYoung/domain/event/service/admin/impl/AdminEventCommandServiceImpl.java
+++ b/src/main/java/hongik/heavyYoung/domain/event/service/admin/impl/AdminEventCommandServiceImpl.java
@@ -18,10 +18,17 @@ public class AdminEventCommandServiceImpl implements AdminEventCommandService {
 
     private final EventRepository eventRepository;
 
+    /**
+     * 새로운 공지사항(Event)을 생성합니다.
+     *
+     * @param eventAddRequestDTO 공지사항 생성에 필요한 제목, 내용, 행사 시작/종료일 정보를 담은 DTO
+     * @return 생성된 공지사항의 PK를 담은 응답 DTO
+     */
     @Override
     @Transactional
     public EventResponse.EventAddResponseDTO createEvent(EventRequest.EventAddRequestDTO eventAddRequestDTO) {
         Event event = EventRequestConverter.toNewEvent(eventAddRequestDTO);
+        // TODO 사진 업로드 방식 결정 후, 공지사항(Event)에 사진 추가 로직 필요
         Event savedEvent = eventRepository.save(event);
         return EventResponseConverter.toEventAddResponseDTO(savedEvent);
     }

--- a/src/main/java/hongik/heavyYoung/domain/event/service/impl/EventQueryServiceImpl.java
+++ b/src/main/java/hongik/heavyYoung/domain/event/service/impl/EventQueryServiceImpl.java
@@ -36,10 +36,10 @@ public class EventQueryServiceImpl implements EventQueryService {
 
         // 시작일, 종료일이 전달된 경우 (기간별 조회)
         if (from != null &&  to!=null) {
-            allEvents = eventRepository.findAllByEventStartDateBetweenOrderByUpdatedAtDesc(from, to);
+            allEvents = eventRepository.findAllByEventStartDateBetweenOrderByCreatedAtDesc(from, to);
         } else {
             // 시작일, 종료일 둘 다 전달되지 않은 경우 (전체 조회)
-            allEvents = eventRepository.findAllByOrderByUpdatedAtDesc();
+            allEvents = eventRepository.findAllByOrderByCreatedAtDesc();
         }
 
         return EventResponseConverter.toEventInfoDTOList(allEvents);

--- a/src/main/java/hongik/heavyYoung/domain/event/service/impl/EventQueryServiceImpl.java
+++ b/src/main/java/hongik/heavyYoung/domain/event/service/impl/EventQueryServiceImpl.java
@@ -5,6 +5,8 @@ import hongik.heavyYoung.domain.event.dto.EventResponse;
 import hongik.heavyYoung.domain.event.entity.Event;
 import hongik.heavyYoung.domain.event.repository.EventRepository;
 import hongik.heavyYoung.domain.event.service.EventQueryService;
+import hongik.heavyYoung.global.apiPayload.status.ErrorStatus;
+import hongik.heavyYoung.global.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,7 +31,7 @@ public class EventQueryServiceImpl implements EventQueryService {
      * @return 조회된 공지사항(Event) 정보 리스트
      */
     @Override
-    public List<EventResponse.EventInfoDTO> getAllEvents(LocalDate from, LocalDate to) {
+    public List<EventResponse.EventInfoDTO> findEvents(LocalDate from, LocalDate to) {
         List<Event> allEvents;
 
         // 시작일, 종료일이 전달된 경우 (기간별 조회)
@@ -41,5 +43,13 @@ public class EventQueryServiceImpl implements EventQueryService {
         }
 
         return EventResponseConverter.toEventInfoDTOList(allEvents);
+    }
+
+    @Override
+    public EventResponse.EventInfoDetailDTO findEventDetails(Long id) {
+        Event event = eventRepository.findByIdWithImages(id)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.EVENT_NOT_FOUND));
+
+        return EventResponseConverter.toEventInfoDetailDTO(event);
     }
 }

--- a/src/main/java/hongik/heavyYoung/domain/event/service/impl/EventQueryServiceImpl.java
+++ b/src/main/java/hongik/heavyYoung/domain/event/service/impl/EventQueryServiceImpl.java
@@ -45,6 +45,15 @@ public class EventQueryServiceImpl implements EventQueryService {
         return EventResponseConverter.toEventInfoDTOList(allEvents);
     }
 
+    /**
+     * 주어진 id에 해당하는 공지사항(Event)의 상세 정보를 조회합니다.
+     * 존재하지 않는 공지사항일 경우, GeneralException(EVENT_NOT_FOUND)가 발생합니다.
+     *
+     *
+     * @param id 조회할 공지사항의 PK
+     * @return 공지사항 상세 정보(제목, 내용, 시작일, 종료일, 생성일자)와 공지사항에 게시된 이미지 목록을 포함한 DTO
+     * @throws GeneralException 해당 ID의 공지사항이 존재하지 않을 경우 발생
+     */
     @Override
     public EventResponse.EventInfoDetailDTO findEventDetails(Long id) {
         Event event = eventRepository.findByIdWithImages(id)

--- a/src/main/java/hongik/heavyYoung/domain/item/entity/Item.java
+++ b/src/main/java/hongik/heavyYoung/domain/item/entity/Item.java
@@ -20,6 +20,9 @@ public class Item extends BaseEntity {
     @JoinColumn(name = "item_category_id", nullable = false)
     private ItemCategory itemCategory;
 
+    @Column(name = "item_code", nullable = false)
+    private int itemCode;
+
     @Column(name = "is_rented", nullable = false)
     @Builder.Default
     private boolean isRented = false;

--- a/src/main/java/hongik/heavyYoung/domain/item/entity/ItemCategory.java
+++ b/src/main/java/hongik/heavyYoung/domain/item/entity/ItemCategory.java
@@ -1,7 +1,6 @@
 // src/main/java/com/yourapp/domain/item/entity/ItemCategory.java
 package hongik.heavyYoung.domain.item.entity;
 
-import hongik.heavyYoung.domain.item.enums.ItemCategoryName;
 import hongik.heavyYoung.global.baseEntity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -18,9 +17,8 @@ public class ItemCategory extends BaseEntity {
     @Column(name = "item_category_id")
     private Long id;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "item_category_name", nullable = false, length = 20)
-    private ItemCategoryName itemCategoryName;
+    @Column(name = "item_category_name", nullable = false, length = 100)
+    private String itemCategoryName;
 
     @Column(name = "total_count", nullable = false)
     @Builder.Default

--- a/src/main/java/hongik/heavyYoung/domain/item/enums/ItemCategoryName.java
+++ b/src/main/java/hongik/heavyYoung/domain/item/enums/ItemCategoryName.java
@@ -1,7 +1,0 @@
-package hongik.heavyYoung.domain.item.enums;
-
-public enum ItemCategoryName {
-    UMBRELLA, // 우산
-    BATTERY, // 보조 배터리
-    LAPTOP_CHARGER, // 노트북 충전기
-}

--- a/src/main/java/hongik/heavyYoung/domain/locker/entity/Locker.java
+++ b/src/main/java/hongik/heavyYoung/domain/locker/entity/Locker.java
@@ -17,8 +17,11 @@ public class Locker extends BaseEntity {
     @Column(name = "locker_id")
     private Long id;
 
-    @Column(name = "locker_number", nullable = false, length = 20)
-    private String lockerNumber;
+    @Column(name = "locker_section", nullable = false, length = 20)
+    private String lockerSection;
+
+    @Column(name = "locker_number", nullable = false)
+    private int lockerNumber;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "locker_status", nullable = false, length = 20)

--- a/src/main/java/hongik/heavyYoung/global/apiPayload/status/ErrorStatus.java
+++ b/src/main/java/hongik/heavyYoung/global/apiPayload/status/ErrorStatus.java
@@ -15,6 +15,7 @@ public enum ErrorStatus implements BaseErrorCode {
     // COMMON 에러
     INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "COMMON_001", "잘못된 요청 파라미터입니다."),
     INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "COMMON_002", "시작일은 종료일보다 이후일 수 없습니다."),
+    VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "COMMON_003", "요청 값이 유효하지 않습니다."),
 
     // EVENT 에러
     EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "EVENT_001", "존재하지 않는 공지사항입니다."),

--- a/src/main/java/hongik/heavyYoung/global/apiPayload/status/ErrorStatus.java
+++ b/src/main/java/hongik/heavyYoung/global/apiPayload/status/ErrorStatus.java
@@ -9,10 +9,17 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum ErrorStatus implements BaseErrorCode {
-
+    // SERVER 에러
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SERVER_001", "서버 에러, 관리자에게 문의 바랍니다."),
+
+    // COMMON 에러
     INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "COMMON_001", "잘못된 요청 파라미터입니다."),
     INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "COMMON_002", "시작일은 종료일보다 이후일 수 없습니다."),
+
+    // EVENT 에러
+    EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "EVENT_001", "존재하지 않는 공지사항입니다."),
+
+    // USER 에러
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_001", "해당 유저가 존재하지 않습니다.");
 
     private final HttpStatus httpStatus;

--- a/src/test/java/hongik/heavyYoung/domain/event/config/AdminEventRestControllerTestConfig.java
+++ b/src/test/java/hongik/heavyYoung/domain/event/config/AdminEventRestControllerTestConfig.java
@@ -1,0 +1,13 @@
+package hongik.heavyYoung.domain.event.config;
+
+import hongik.heavyYoung.domain.event.service.admin.AdminEventCommandService;
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class AdminEventRestControllerTestConfig {
+
+    @Bean
+    public AdminEventCommandService adminEventCommandService() { return Mockito.mock(AdminEventCommandService.class); }
+}

--- a/src/test/java/hongik/heavyYoung/domain/event/integration/AdminEventIntegrationTest.java
+++ b/src/test/java/hongik/heavyYoung/domain/event/integration/AdminEventIntegrationTest.java
@@ -1,0 +1,65 @@
+package hongik.heavyYoung.domain.event.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import hongik.heavyYoung.domain.event.dto.EventRequest;
+import hongik.heavyYoung.domain.event.entity.Event;
+import hongik.heavyYoung.domain.event.repository.EventRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.time.LocalDate;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class AdminEventIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @Test
+    @DisplayName("공지사항 생성 성공")
+    void addEvent_Success() throws Exception{
+        // given
+        EventRequest.EventAddRequestDTO request = EventRequest.EventAddRequestDTO.builder()
+                .title("간식행사")
+                .content("간식행사 세부 일정")
+                .eventStartDate(LocalDate.of(2025, 9, 1))
+                .eventEndDate(LocalDate.of(2025, 9, 2))
+                .build();
+
+        // when
+        ResultActions result = mockMvc.perform(post("/admin/event")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+        // then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.result.eventId").isNumber());
+
+        // then
+        Event savedEvent = eventRepository.findAll().getFirst();
+        result.andExpect(jsonPath("$.result.eventId").value(savedEvent.getId()));
+    }
+}

--- a/src/test/java/hongik/heavyYoung/domain/event/integration/EventIntegrationTest.java
+++ b/src/test/java/hongik/heavyYoung/domain/event/integration/EventIntegrationTest.java
@@ -13,6 +13,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -83,9 +84,14 @@ class EventIntegrationTest {
     @Test
     @DisplayName("공지사항 조회(전체) 통합테스트")
     void getEvents_All_API() throws Exception{
-        mockMvc.perform(get("/events")
-                    .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
+        // given
+
+        //when
+        ResultActions result = mockMvc.perform(get("/events")
+                    .accept(MediaType.APPLICATION_JSON));
+
+        // then
+        result.andExpect(status().isOk())
                 .andExpect(jsonPath("$.isSuccess").value(true))
                 .andExpect(jsonPath("$.result.length()").value(3))
                 .andExpect(jsonPath("$.result[0].title").value("운동행사"))
@@ -103,11 +109,16 @@ class EventIntegrationTest {
     @Test
     @DisplayName("공지사항 조회(기간별) 통합테스트")
     void getEvents_Period_API() throws Exception{
-        mockMvc.perform(get("/events")
-                        .param("from", "2025-09-01")
-                        .param("to", "2025-09-30")
-                        .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
+        // given
+
+        //when
+        ResultActions result = mockMvc.perform(get("/events")
+                .param("from", "2025-09-01")
+                .param("to", "2025-09-30")
+                .accept(MediaType.APPLICATION_JSON));
+
+        // then
+        result.andExpect(status().isOk())
                 .andExpect(jsonPath("$.isSuccess").value(true))
                 .andExpect(jsonPath("$.result.length()").value(2))
                 .andExpect(jsonPath("$.result[0].title").value("운동행사"))
@@ -121,9 +132,14 @@ class EventIntegrationTest {
     @Test
     @DisplayName("공지사항 상세 조회(사진포함) 테스트")
     void getEventDetails() throws Exception{
-        mockMvc.perform(get("/events/{eventId}", 1L)
-                        .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
+        // given
+
+        // when
+        ResultActions result = mockMvc.perform(get("/events/{eventId}", 1L)
+                .accept(MediaType.APPLICATION_JSON));
+
+        //then
+        result.andExpect(status().isOk())
                 .andExpect(jsonPath("$.isSuccess").value(true))
                 .andExpect(jsonPath("$.result.title").value("간식행사"))
                 .andExpect(jsonPath("$.result.content").value("간식행사 상세 일정"))

--- a/src/test/java/hongik/heavyYoung/domain/event/integration/EventIntegrationTest.java
+++ b/src/test/java/hongik/heavyYoung/domain/event/integration/EventIntegrationTest.java
@@ -1,6 +1,7 @@
 package hongik.heavyYoung.domain.event.integration;
 
 import hongik.heavyYoung.domain.event.entity.Event;
+import hongik.heavyYoung.domain.event.entity.EventImage;
 import hongik.heavyYoung.domain.event.repository.EventRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -13,6 +14,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -38,6 +40,21 @@ class EventIntegrationTest {
                 .eventStartDate(LocalDate.of(2025, 9, 1))
                 .eventEndDate(LocalDate.of(2025, 9, 2))
                 .build();
+
+        EventImage eventImage1 = EventImage.builder()
+                .event(event1)
+                .eventImageUrl("url1")
+                .sortOrder(1)
+                .build();
+
+        EventImage eventImage2 = EventImage.builder()
+                .event(event1)
+                .eventImageUrl("url2")
+                .sortOrder(2)
+                .build();
+
+        event1.getEventImages().add(eventImage1);
+        event1.getEventImages().add(eventImage2);
 
         Event event2 = Event.builder()
                 .eventTitle("나눔행사")
@@ -99,6 +116,22 @@ class EventIntegrationTest {
                 .andExpect(jsonPath("$.result[1].title").value("간식행사"))
                 .andExpect(jsonPath("$.result[1].eventStartDate").value("2025-09-01"))
                 .andExpect(jsonPath("$.result[1].eventEndDate").value("2025-09-02"));
+    }
+
+    @Test
+    @DisplayName("공지사항 상세 조회(사진포함) 테스트")
+    void getEventDetails() throws Exception{
+        mockMvc.perform(get("/events/{eventId}", 1L)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.result.title").value("간식행사"))
+                .andExpect(jsonPath("$.result.content").value("간식행사 상세 일정"))
+                .andExpect(jsonPath("$.result.eventStartDate").value("2025-09-01"))
+                .andExpect(jsonPath("$.result.eventEndDate").value("2025-09-02"))
+                .andExpect(jsonPath("$.result.imageUrls", hasSize(2)))
+                .andExpect(jsonPath("$.result.imageUrls[0]").value("url1"))
+                .andExpect(jsonPath("$.result.imageUrls[1]").value("url2"));
     }
 
 }

--- a/src/test/java/hongik/heavyYoung/domain/event/repository/EventRepositoryTest.java
+++ b/src/test/java/hongik/heavyYoung/domain/event/repository/EventRepositoryTest.java
@@ -26,7 +26,7 @@ class EventRepositoryTest {
 
     @Test
     @DisplayName("공지사항 조회(전체) 성공")
-    void findAllByOrderByUpdatedAtDesc(){
+    void findAllByOrderByCreatedAtDesc() {
         // given
         Event event1 = Event.builder()
                 .eventTitle("간식행사")
@@ -46,7 +46,7 @@ class EventRepositoryTest {
         eventRepository.save(event2);
 
         // when
-        List<Event> result = eventRepository.findAllByOrderByUpdatedAtDesc();
+        List<Event> result = eventRepository.findAllByOrderByCreatedAtDesc();
 
         // then
         assertThat(result).hasSize(2);
@@ -56,7 +56,7 @@ class EventRepositoryTest {
 
     @Test
     @DisplayName("공지사항 조회(기간별) 성공")
-    void findAllByEventStartDateBetweenOrderByUpdatedAtDesc() {
+    void findAllByEventStartDateBetweenOrderByCreatedAtDesc() {
         // given
         Event event1 = Event.builder()
                 .eventTitle("간식행사")
@@ -84,7 +84,7 @@ class EventRepositoryTest {
         eventRepository.save(event3);
 
         // when
-        List<Event> result = eventRepository.findAllByEventStartDateBetweenOrderByUpdatedAtDesc(
+        List<Event> result = eventRepository.findAllByEventStartDateBetweenOrderByCreatedAtDesc(
                 LocalDate.of(2025, 9, 1),
                 LocalDate.of(2025, 9, 30)
         );
@@ -128,6 +128,7 @@ class EventRepositoryTest {
                 .orElseThrow(() -> new GeneralException(ErrorStatus.EVENT_NOT_FOUND));
 
         // then
+        assertEquals(result.getEventContent(), "간식행사 상세 일정");
         assertThat(result.getEventImages()).hasSize(2);
         assertThat(result.getEventImages().getFirst().getEventImageUrl())
                 .isEqualTo("url1");

--- a/src/test/java/hongik/heavyYoung/domain/event/repository/EventRepositoryTest.java
+++ b/src/test/java/hongik/heavyYoung/domain/event/repository/EventRepositoryTest.java
@@ -1,7 +1,10 @@
 package hongik.heavyYoung.domain.event.repository;
 
 import hongik.heavyYoung.domain.event.entity.Event;
+import hongik.heavyYoung.domain.event.entity.EventImage;
+import hongik.heavyYoung.global.apiPayload.status.ErrorStatus;
 import hongik.heavyYoung.global.config.TestJpaAuditingConfig;
+import hongik.heavyYoung.global.exception.GeneralException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -90,5 +93,43 @@ class EventRepositoryTest {
         assertThat(result).hasSize(2);
         assertEquals(result.getFirst().getEventTitle(), "운동행사");
         assertEquals(result.get(1).getEventTitle(), "간식행사");
+    }
+
+    @Test
+    @DisplayName("공지사항 상세 조회(사진포함) 성공")
+    void findByIdWithImages(){
+        // given
+        Event event1 = Event.builder()
+                .eventTitle("간식행사")
+                .eventContent("간식행사 상세 일정")
+                .eventStartDate(LocalDate.of(2025, 9, 1))
+                .eventEndDate(LocalDate.of(2025, 9, 2))
+                .build();
+
+        eventRepository.save(event1);
+
+        EventImage eventImage1 = EventImage.builder()
+                .event(event1)
+                .eventImageUrl("url1")
+                .sortOrder(1)
+                .build();
+
+        EventImage eventImage2 = EventImage.builder()
+                .event(event1)
+                .eventImageUrl("url2")
+                .sortOrder(2)
+                .build();
+
+        event1.getEventImages().add(eventImage1);
+        event1.getEventImages().add(eventImage2);
+
+        // when
+        Event result = eventRepository.findByIdWithImages(event1.getId())
+                .orElseThrow(() -> new GeneralException(ErrorStatus.EVENT_NOT_FOUND));
+
+        // then
+        assertThat(result.getEventImages()).hasSize(2);
+        assertThat(result.getEventImages().getFirst().getEventImageUrl())
+                .isEqualTo("url1");
     }
 }

--- a/src/test/java/hongik/heavyYoung/domain/event/service/admin/impl/AdminEventCommandServiceImplTest.java
+++ b/src/test/java/hongik/heavyYoung/domain/event/service/admin/impl/AdminEventCommandServiceImplTest.java
@@ -1,0 +1,61 @@
+package hongik.heavyYoung.domain.event.service.admin.impl;
+
+import hongik.heavyYoung.domain.event.dto.EventRequest;
+import hongik.heavyYoung.domain.event.dto.EventResponse;
+import hongik.heavyYoung.domain.event.entity.Event;
+import hongik.heavyYoung.domain.event.repository.EventRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AdminEventCommandServiceImplTest {
+
+    @Mock
+    private EventRepository eventRepository;
+
+    @InjectMocks
+    private AdminEventCommandServiceImpl adminEventCommandService;
+
+    @Test
+    @DisplayName("공지사항 생성 성공")
+    void createEvent(){
+        // given
+        EventRequest.EventAddRequestDTO eventAddRequestDTO = EventRequest.EventAddRequestDTO.builder()
+                .title("간식행사")
+                .content("간식행사 세부 일정")
+                .eventStartDate(LocalDate.of(2025, 9, 1))
+                .eventEndDate(LocalDate.of(2025, 9, 2))
+                .build();
+
+        Event fakeSavedEvent = Event.builder()
+                .id(1L)
+                .eventTitle("간식행사")
+                .eventContent("간식행사 세부 일정")
+                .eventStartDate(LocalDate.of(2025, 9, 1))
+                .eventEndDate(LocalDate.of(2025, 9, 2))
+                .build();
+
+        given(eventRepository.save(any(Event.class))).willReturn(fakeSavedEvent);
+
+        // when
+        EventResponse.EventAddResponseDTO eventAddResponseDTO = adminEventCommandService.createEvent(eventAddRequestDTO);
+
+        // then
+        assertThat(eventAddResponseDTO.getEventId()).isEqualTo(1L);
+        verify(eventRepository, times(1)).save(any(Event.class));
+    }
+
+
+}

--- a/src/test/java/hongik/heavyYoung/domain/event/service/impl/EventQueryServiceImplTest.java
+++ b/src/test/java/hongik/heavyYoung/domain/event/service/impl/EventQueryServiceImplTest.java
@@ -56,7 +56,7 @@ class EventQueryServiceImplTest {
         events.add(event2);
         events.add(event1);
 
-        given(eventRepository.findAllByOrderByUpdatedAtDesc()).willReturn(events);
+        given(eventRepository.findAllByOrderByCreatedAtDesc()).willReturn(events);
 
         // when
         List<EventResponse.EventInfoDTO> result = eventQueryService.findEvents(null, null);
@@ -96,7 +96,7 @@ class EventQueryServiceImplTest {
         events.add(event2);
         events.add(event1);
 
-        given(eventRepository.findAllByEventStartDateBetweenOrderByUpdatedAtDesc(from,to)).willReturn(events);
+        given(eventRepository.findAllByEventStartDateBetweenOrderByCreatedAtDesc(from,to)).willReturn(events);
 
         // when
         List<EventResponse.EventInfoDTO> result = eventQueryService.findEvents(from, to);
@@ -108,7 +108,7 @@ class EventQueryServiceImplTest {
 
     @Test
     @DisplayName("공지사항 상세 조회(사진포함) 성공")
-    void findEventDetails(){
+    void findEventDetails() {
         // given
         Event event1 = Event.builder()
                 .id(1L)


### PR DESCRIPTION
## 🔗 관련 이슈
- closes #7 

## 📖 변경 사항 요약
- 공지사항 생성 기능 구현
- 공지사항 상세보기 기능 구현
- @Valid 검증 실패에 대한 공통 예외처리 추가 (MethodArgumentNotValidException)
- Request Body에 잘못된 값, JSON 파싱 오류에 대한 공통 예외처리 추가 (HttpMessageNotReadableException)
- Event 엔티티에 List<EventImage> 양방향 매핑 추가
- 테스트 코드 given, when, then 구조로 리팩토링

## 🛠 구현 내용 및 상세
**1. 공지사항 상세보기 기능 구현**
- 공지사항 상세보기 기능을 구현하였습니다.
- 잘못된 PathVariable 형식의 입력시 이전에 MethodArgumentTypeMismatchException 공통 예외 처리 한 것으로, ErrorStatus.INVALID_PARAMETER 오류가 나가게 했습니다.
- 또한, 존재하지 않는 EventId 값 입력시 GeneralException 예외로, ErrorStatus.EVENT_NOT_FOUND 오류가 나게 했습니다.
- 공지사항 상세 조회시에 EventImage에 대해 LEFT JOIN을 걸어 이미지가 없는 공지사항도 가져오게 하였고, JOIN FETCH를 걸어두어 N+1 문제를 방지했습니다.
- 테스트 코드 작성도 완료했습니다. (단위테스트, 통합테스트)


**2. 공지사항 생성 기능 구현**
- 공지사항 생성 기능을 구현하였습니다.
- RequestBody에 @Valid 검증 실패한 DTO에 대해서, RequestBody에 어떤 필드들이 잘못되었는지에 대한 에러메시지를 모두 보내주도록 공통 예외처리를 하였습니다.
- RequestBody에 잘못된 형식이 입력된 경우(ex. 2025-19-81) JSON 파싱 오류에 대해 공통 응답을 추가하였습니다.
- 테스트 코드 작성도 완료했습니다. (단위테스트, 통합테스트)


**3. Event, EventImage 양방향 매핑**
- Event 엔티티에 EventImage를 양방향 매핑 하였습니다. 상세보기에만 이미지를 조회를 할 것이고, 전체 조회시 EventImage를 가져오지 않아야 해서, 성능 때문에 걱정을 했지만, EventImage의 fetch type을 lazy로 걸어두어, 공지사항 전체조회(월별조회)시에는 EventImage 테이블을 가져오지 않게 해놓았습니다. 또한, 양방향 매핑 후 Cascading 처리, orphanremoval 적용을 통해, event가 없는 eventImage가 생길 수 없게 막아 두었습니다. 


## 📋 리뷰 요구사항
- 양방향 매핑 관련해서 확인 부탁드립니다.
- 에러 메시지, 에러 코드가 괜찮은지 확인 부탁드립니다.

## 💬 참고 사항
- 이후, ConstraintValidException 공통 예외 처리도 추가해야할 것 같습니다. 현재는 제약조건(ex. 최소,최대) 을 걸어놔야하는 파라미터 상황이 없어, 추가하지 않았습니다.