### PR TITLE
[#38] 대여 물품 수동 반납

### DIFF
--- a/src/main/java/hongik/heavyYoung/domain/rental/controller/RentalAdminRestController.java
+++ b/src/main/java/hongik/heavyYoung/domain/rental/controller/RentalAdminRestController.java
@@ -38,4 +38,11 @@ public class RentalAdminRestController {
         rentalAdminCommandService.returnByQr(request);
         return ApiResponse.onSuccess(null);
     }
+
+    @Operation(summary = "물품 수동 반납")
+    @PostMapping("/{rental-history-id}/return")
+    public ApiResponse<?> manualReturn (@PathVariable("rental-history-id") Long rentalHistoryId) {
+        rentalAdminCommandService.manualReturn(rentalHistoryId);
+        return ApiResponse.onSuccess(null);
+    }
 }

--- a/src/main/java/hongik/heavyYoung/domain/rental/service/RentalAdminCommandService.java
+++ b/src/main/java/hongik/heavyYoung/domain/rental/service/RentalAdminCommandService.java
@@ -5,4 +5,5 @@ import hongik.heavyYoung.domain.rental.dto.RentalRequestDTO;
 public interface RentalAdminCommandService {
     void rentalByQr(RentalRequestDTO.QrToken qrToken);
     void returnByQr(RentalRequestDTO.QrToken request);
+    void manualReturn(Long rentalHistoryId);
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- 이 PR과 연결된 이슈 번호를 적어주세요.
closes #38 

## 📖 변경 사항 요약
- 변경된 주요 기능 및 의도한 동작을 간략히 기술해주세요.
대여 물품 수동 반납 기능 구현

## 🛠 구현 내용 및 상세
rentalHistoryId를 통해, 해당 대여 내역을 수동으로 반납처리

## 📋 리뷰 요구사항
- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 💬 참고 사항
- 추가로 알려야 할 사항이나 리뷰어에게 질문할 것이 있으면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 관리자 대시보드에 물품 수동 반납 기능 추가. 관리자는 특정 대여 기록을 선택하여 수동으로 물품을 반납할 수 있습니다. 반납 처리 로직이 통합되어 체계적으로 관리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->