### PR TITLE
[#42]: OpenAI를 이용한 챗봇 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,9 @@ configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
+    all {
+        exclude group: "io.swagger.core.v3", module: "swagger-annotations"
+    }
 }
 
 repositories {
@@ -69,9 +72,8 @@ dependencies {
     // Email
     implementation 'org.springframework.boot:spring-boot-starter-mail'
 
-
-
-
+    // Spring AI
+    implementation 'org.springframework.ai:spring-ai-starter-model-openai:1.0.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/hongik/heavyYoung/domain/chat/controller/ChatRestController.java
+++ b/src/main/java/hongik/heavyYoung/domain/chat/controller/ChatRestController.java
@@ -1,0 +1,28 @@
+package hongik.heavyYoung.domain.chat.controller;
+
+import hongik.heavyYoung.domain.chat.dto.ChatResponseDTO;
+import hongik.heavyYoung.domain.chat.service.ChatCommandService;
+import hongik.heavyYoung.domain.chat.dto.ChatRequestDTO;
+import hongik.heavyYoung.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Chatbot API - 학생", description = "학생 - 챗봇 API")
+@RestController
+@RequestMapping("/chat")
+@RequiredArgsConstructor
+public class ChatRestController {
+
+    private final ChatCommandService chatCommandService;
+
+    @Operation(summary = "챗봇 응답 받기")
+    @PostMapping
+    public ApiResponse<ChatResponseDTO.Response> getChatResponse(@RequestBody ChatRequestDTO.Request request) {
+        return ApiResponse.onSuccess(chatCommandService.getChatResponse(request));
+    }
+}

--- a/src/main/java/hongik/heavyYoung/domain/chat/converter/ChatConverter.java
+++ b/src/main/java/hongik/heavyYoung/domain/chat/converter/ChatConverter.java
@@ -1,0 +1,11 @@
+package hongik.heavyYoung.domain.chat.converter;
+
+import hongik.heavyYoung.domain.chat.dto.ChatResponseDTO;
+
+public class ChatConverter {
+    public static ChatResponseDTO.Response toResponseDTO(String response) {
+        return ChatResponseDTO.Response.builder()
+                .content(response)
+                .build();
+    }
+}

--- a/src/main/java/hongik/heavyYoung/domain/chat/dto/ChatRequestDTO.java
+++ b/src/main/java/hongik/heavyYoung/domain/chat/dto/ChatRequestDTO.java
@@ -1,0 +1,17 @@
+package hongik.heavyYoung.domain.chat.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class ChatRequestDTO {
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Request {
+        private String content;
+
+    }
+}

--- a/src/main/java/hongik/heavyYoung/domain/chat/dto/ChatResponseDTO.java
+++ b/src/main/java/hongik/heavyYoung/domain/chat/dto/ChatResponseDTO.java
@@ -1,0 +1,16 @@
+package hongik.heavyYoung.domain.chat.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class ChatResponseDTO {
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Response {
+        private String content;
+    }
+}

--- a/src/main/java/hongik/heavyYoung/domain/chat/service/ChatCommandService.java
+++ b/src/main/java/hongik/heavyYoung/domain/chat/service/ChatCommandService.java
@@ -1,0 +1,8 @@
+package hongik.heavyYoung.domain.chat.service;
+
+import hongik.heavyYoung.domain.chat.dto.ChatRequestDTO;
+import hongik.heavyYoung.domain.chat.dto.ChatResponseDTO;
+
+public interface ChatCommandService {
+    ChatResponseDTO.Response getChatResponse(ChatRequestDTO.Request request);
+}

--- a/src/main/java/hongik/heavyYoung/domain/chat/service/ChatCommandServiceImpl.java
+++ b/src/main/java/hongik/heavyYoung/domain/chat/service/ChatCommandServiceImpl.java
@@ -1,0 +1,50 @@
+package hongik.heavyYoung.domain.chat.service;
+
+import hongik.heavyYoung.domain.chat.converter.ChatConverter;
+import hongik.heavyYoung.domain.chat.dto.ChatRequestDTO;
+import hongik.heavyYoung.domain.chat.dto.ChatResponseDTO;
+import hongik.heavyYoung.global.ai.AIClient;
+import hongik.heavyYoung.global.ai.PromptFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ChatCommandServiceImpl implements ChatCommandService {
+
+    private final AIClient aiClient;
+    private final ChatMemory chatMemory;
+
+    @Override
+    public ChatResponseDTO.Response getChatResponse(ChatRequestDTO.Request request) {
+        Long memberId = 1L;
+
+        // 채팅 히스토리 가져오기
+        List<Message> chatHistory = new ArrayList<>(chatMemory.get(String.valueOf(memberId)));
+
+        // 사용자 메시지 추가
+        chatHistory.add(new UserMessage(request.getContent()));
+
+        // 프롬프트 생성
+        Prompt prompt = PromptFactory.buildPrompt(chatHistory);
+
+        // AI 클라이언트를 통해 응답 받기
+        String response = aiClient.getResponse(prompt);
+
+        // 대화 히스토리에 사용자 메시지와 어시스턴트 메시지 추가
+        chatMemory.add(String.valueOf(memberId), new UserMessage(request.getContent()));
+        chatMemory.add(String.valueOf(memberId), new AssistantMessage(response));
+
+        return ChatConverter.toResponseDTO(response);
+    }
+}

--- a/src/main/java/hongik/heavyYoung/global/ai/AIClient.java
+++ b/src/main/java/hongik/heavyYoung/global/ai/AIClient.java
@@ -1,0 +1,49 @@
+package hongik.heavyYoung.global.ai;
+
+import hongik.heavyYoung.global.apiPayload.status.ErrorStatus;
+import hongik.heavyYoung.global.exception.customException.ChatException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AIClient {
+
+    private final OpenAiChatModel openAiChatModel;
+
+    public String getResponse(Prompt prompt) {
+        ChatClient chatClient = ChatClient.create(openAiChatModel);
+
+        try {
+            return chatClient.prompt(prompt).call().content();
+        } catch (RestClientException e) {
+            String msg = e.getMessage();
+            log.error("에러 내용 {}", msg);
+
+            if (msg == null) {
+                throw new ChatException(ErrorStatus.OPEN_AI_SERVER_ERROR);
+            }
+
+            String lowerMsg = msg.toLowerCase(); // 에러 메시지 소문자로 변경
+
+            if (lowerMsg.contains("401") || lowerMsg.contains("unauthorized")) {
+                throw new ChatException(ErrorStatus.INVALID_API_KEY);
+            }
+            if (lowerMsg.contains("429")) {
+                throw new ChatException(ErrorStatus.QUOTA_EXCEEDED);
+            }
+            if (lowerMsg.contains("openaiapi$chatcompletion")) {
+                throw new ChatException(ErrorStatus.INVALID_API_KEY);
+            }
+
+            throw new ChatException(ErrorStatus.OPEN_AI_SERVER_ERROR);
+        }
+    }
+}
+

--- a/src/main/java/hongik/heavyYoung/global/ai/PromptFactory.java
+++ b/src/main/java/hongik/heavyYoung/global/ai/PromptFactory.java
@@ -1,0 +1,53 @@
+package hongik.heavyYoung.global.ai;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.openai.OpenAiChatOptions;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 챗봇 프롬프트(대화 맥락) 생성 유틸리티 클래스.
+ */
+@Slf4j
+public class PromptFactory {
+    private static final String HEAVYYOUNG_SYSTEM_PROMPT = """
+            넌 학생회비 통합 관리 플랫폼 회비영이야. 사람들은 나에게 학생회비와 관련된 질문을 해.
+            나는 사용자가 학생회비와 관련된 질문을 하면, 최대한 친절하고 정확하게 답변해줘야 해.
+            학생회비 납부여부 확인, 물품 대여, 공지사항, 사물함 관리 등 학생회비와 관련된 다양한 주제에 대해 답변할 수 있어야 해.
+            너가 행사 참여를 위해, 학생회비 납부 여부를 확인하려면, 하단 메뉴바 첫번째 QR코드를 눌러서 확인할 수 있다고 안내해줘.
+            물품 관련된 질문을 받으면, 하단 메뉴바 두번째 물품대여 탭에서 대여할 수 있다고 안내해줘.
+            공지사항 관련된 질문을 받으면, 하단 메뉴바 세번째 공지사항 탭에서 확인할 수 있다고 안내해줘.
+            사물함 관련된 질문을 받으면, 하단 메뉴바 네번째 사물함 탭에서 관리할 수 있다고 안내해줘.
+            마이 페이지는 학생회비 납부, 개인정보 수정, 비밀번호 변경 등을 할 수 있는 곳이라고 안내해줘.
+            항상 학생회비와 관련된 정보만 제공하고, 학생회비와 관련 없는 질문에는 답변하지 마.
+        """;
+
+    /**
+     * OpenAI 모델 호출 시 사용할 옵션
+     * model: 사용할 LLM 모델 이름
+     * temperature: 창의성 조절 (0에 가까울수록 사실 기반, 할루시네이션 낮아짐)
+     */
+    private static final OpenAiChatOptions options = OpenAiChatOptions.builder()
+            .model("gpt-4.1-mini")
+            .temperature(0.7)
+            .build();
+
+    public static Prompt buildPrompt(List<Message> chatHistory) {
+        Message systemMessage = SystemMessage.builder()
+                .text(HEAVYYOUNG_SYSTEM_PROMPT)
+                .build();
+
+        List<Message> messages = new ArrayList<>();
+        messages.add(systemMessage);
+        messages.addAll(chatHistory);
+
+        return Prompt.builder()
+                .messages(messages)
+                .chatOptions(options)
+                .build();
+    }
+}

--- a/src/main/java/hongik/heavyYoung/global/apiPayload/status/ErrorStatus.java
+++ b/src/main/java/hongik/heavyYoung/global/apiPayload/status/ErrorStatus.java
@@ -88,7 +88,12 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // S3 에러
     S3_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "S3_001", "이미지 업로드 중 오류가 발생했습니다."),
-    S3_DELETE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "S3_002", "이미지 삭제 중 오류가 발생했습니다.");
+    S3_DELETE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "S3_002", "이미지 삭제 중 오류가 발생했습니다."),
+
+    // 채팅 관련
+    INVALID_API_KEY(HttpStatus.UNAUTHORIZED, "CHAT4001", "API 키가 잘못됐습니다."),
+    QUOTA_EXCEEDED(HttpStatus.FORBIDDEN, "CHAT4002", "API 쿼터가 모두 소진되었습니다."),
+    OPEN_AI_SERVER_ERROR(HttpStatus.BAD_GATEWAY, "CHAT4003", "OpenAI 서버에 연결할 수 없습니다. 잠시 후 다시 시도해주세요.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/hongik/heavyYoung/global/config/AIConfig.java
+++ b/src/main/java/hongik/heavyYoung/global/config/AIConfig.java
@@ -1,0 +1,30 @@
+package hongik.heavyYoung.global.config;
+
+import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.ai.chat.memory.ChatMemoryRepository;
+import org.springframework.ai.chat.memory.InMemoryChatMemoryRepository;
+import org.springframework.ai.chat.memory.MessageWindowChatMemory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AIConfig {
+
+    @Bean
+    public ChatMemoryRepository chatMemoryRepository() {
+        return new InMemoryChatMemoryRepository();
+    }
+
+    /**
+     * 최근 대화 기록을 관리하는 메모리 기반 슬라이딩 윈도우
+     * 최대 최근 메시지 10개 보관
+     * ChatMemoryRepository의 구현체에 따라 저장소 방식이 달라질 수 있음
+     */
+    @Bean
+    public ChatMemory chatMemory(ChatMemoryRepository chatMemoryRepository) {
+        return MessageWindowChatMemory.builder()
+                .maxMessages(10)
+                .chatMemoryRepository(chatMemoryRepository)
+                .build();
+    }
+}

--- a/src/main/java/hongik/heavyYoung/global/exception/customException/ChatException.java
+++ b/src/main/java/hongik/heavyYoung/global/exception/customException/ChatException.java
@@ -1,0 +1,10 @@
+package hongik.heavyYoung.global.exception.customException;
+
+import hongik.heavyYoung.global.apiPayload.code.BaseErrorCode;
+import hongik.heavyYoung.global.exception.GeneralException;
+
+public class ChatException extends GeneralException {
+    public ChatException(BaseErrorCode baseErrorCode) {
+        super(baseErrorCode);
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- 이 PR과 연결된 이슈 번호를 적어주세요.
closes #42 

## 📖 변경 사항 요약
회비영 앱 사용 방법을 안내해주는 챗봇 구현

## 🛠 구현 내용 및 상세
AI 채팅봇 서비스 추가: OpenAI 기반의 실시간 상담 채팅 기능 시작
대화 이력 관리: 최대 10개 메시지의 채팅 기록 자동 유지로 맥락 있는 대화 지원
오류 처리 강화: API 키 오류, 할당량 초과, 서버 연결 문제 등에 대한 사용자 친화적 오류 메시지 제공

## 📋 리뷰 요구사항
- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 💬 참고 사항
- 추가로 알려야 할 사항이나 리뷰어에게 질문할 것이 있으면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * AI 채팅봇 서비스 추가: OpenAI 기반의 실시간 상담 채팅 기능 시작
  * 대화 이력 관리: 최대 10개 메시지의 채팅 기록 자동 유지로 맥락 있는 대화 지원
  * 오류 처리 강화: API 키 오류, 할당량 초과, 서버 연결 문제 등에 대한 사용자 친화적 오류 메시지 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->